### PR TITLE
See through fix

### DIFF
--- a/hw/xbox/nv2a/pgraph/gl/shaders.c
+++ b/hw/xbox/nv2a/pgraph/gl/shaders.c
@@ -219,7 +219,9 @@ static ShaderBinding *generate_shaders(const ShaderState *state)
                                  state->polygon_back_mode,
                                  state->primitive_mode,
                                  state->smooth_shading,
-                                 false);
+                                 false,
+                                 state->z_perspective
+            );
     if (geometry_shader_code) {
         const char* geometry_shader_code_str =
              mstring_get_str(geometry_shader_code);
@@ -240,7 +242,7 @@ static ShaderBinding *generate_shaders(const ShaderState *state)
     mstring_unref(vertex_shader_code);
 
     /* generate a fragment shader from register combiners */
-    MString *fragment_shader_code = pgraph_gen_psh_glsl(state->psh);
+    MString *fragment_shader_code = pgraph_gen_psh_glsl(state->psh, state->z_perspective);
     const char *fragment_shader_code_str =
         mstring_get_str(fragment_shader_code);
     GLuint fragment_shader = create_gl_shader(GL_FRAGMENT_SHADER,

--- a/hw/xbox/nv2a/pgraph/glsl/common.c
+++ b/hw/xbox/nv2a/pgraph/glsl/common.c
@@ -21,13 +21,13 @@
 #include "common.h"
 
 
-MString *pgraph_get_glsl_vtx_header(MString *out, bool location, bool smooth, bool in, bool prefix, bool array)
+MString *pgraph_get_glsl_vtx_header(MString *out, bool location, bool smooth, bool in, bool prefix, bool array, bool z_perspective)
 {
     const char *flat_s = "flat";
-    const char *noperspective_s = "noperspective";
+    const char *noperspective_s = z_perspective ? "" : "noperspective";
     const char *qualifier_s = smooth ? noperspective_s : flat_s;
     const char *qualifiers[11] = {
-        noperspective_s, flat_s,          qualifier_s,     qualifier_s,
+        "noperspective", flat_s,          qualifier_s,     qualifier_s,
         qualifier_s,     qualifier_s,     noperspective_s, noperspective_s,
         noperspective_s, noperspective_s, noperspective_s
     };

--- a/hw/xbox/nv2a/pgraph/glsl/common.h
+++ b/hw/xbox/nv2a/pgraph/glsl/common.h
@@ -33,6 +33,6 @@
 
 #define GLSL_DEFINE(a, b) "#define " stringify(a) " " b "\n"
 
-MString *pgraph_get_glsl_vtx_header(MString *out, bool location, bool smooth, bool in, bool prefix, bool array);
+MString *pgraph_get_glsl_vtx_header(MString *out, bool location, bool smooth, bool in, bool prefix, bool array, bool z_perspective);
 
 #endif

--- a/hw/xbox/nv2a/pgraph/glsl/geom.c
+++ b/hw/xbox/nv2a/pgraph/glsl/geom.c
@@ -27,7 +27,8 @@ MString *pgraph_gen_geom_glsl(enum ShaderPolygonMode polygon_front_mode,
                               enum ShaderPolygonMode polygon_back_mode,
                               enum ShaderPrimitiveMode primitive_mode,
                               bool smooth_shading,
-                              bool vulkan)
+                              bool vulkan,
+                              bool z_perspective)
 {
     /* FIXME: Missing support for 2-sided-poly mode */
     assert(polygon_front_mode == polygon_back_mode);
@@ -174,8 +175,8 @@ MString *pgraph_gen_geom_glsl(enum ShaderPolygonMode polygon_front_mode,
     mstring_append(s, layout_in);
     mstring_append(s, layout_out);
     mstring_append(s, "\n");
-    pgraph_get_glsl_vtx_header(s, vulkan, smooth_shading, true, true, true);
-    pgraph_get_glsl_vtx_header(s, vulkan, smooth_shading, false, false, false);
+    pgraph_get_glsl_vtx_header(s, vulkan, smooth_shading, true, true, true, z_perspective);
+    pgraph_get_glsl_vtx_header(s, vulkan, smooth_shading, false, false, false, z_perspective);
 
     if (smooth_shading) {
         mstring_append(s,

--- a/hw/xbox/nv2a/pgraph/glsl/geom.h
+++ b/hw/xbox/nv2a/pgraph/glsl/geom.h
@@ -29,6 +29,7 @@ MString *pgraph_gen_geom_glsl(enum ShaderPolygonMode polygon_front_mode,
                               enum ShaderPolygonMode polygon_back_mode,
                               enum ShaderPrimitiveMode primitive_mode,
                               bool smooth_shading,
-                              bool vulkan);
+                              bool vulkan,
+                              bool z_perspective);
 
 #endif

--- a/hw/xbox/nv2a/pgraph/glsl/psh.h
+++ b/hw/xbox/nv2a/pgraph/glsl/psh.h
@@ -36,6 +36,6 @@
 #define PSH_UBO_BINDING 1
 #define PSH_TEX_BINDING 2
 
-MString *pgraph_gen_psh_glsl(const PshState state);
+MString *pgraph_gen_psh_glsl(const PshState state, bool z_perspective);
 
 #endif

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -173,6 +173,7 @@ typedef struct ShaderBinding {
 
     int surface_size_loc;
     int clip_range_loc;
+    int clip_range_loc_frag;
 
     int vsh_constant_loc;
     uint32_t vsh_constants[NV2A_VERTEXSHADER_CONSTANTS][4];

--- a/hw/xbox/nv2a/pgraph/vk/shaders.c
+++ b/hw/xbox/nv2a/pgraph/vk/shaders.c
@@ -310,6 +310,9 @@ static void update_shader_constant_locations(ShaderBinding *binding)
 
     binding->uniform_attrs_loc =
         uniform_index(&binding->vertex->uniforms, "inlineValue");
+
+    binding->clip_range_loc_frag =
+        uniform_index(&binding->fragment->uniforms, "clipRange");
 }
 
 static void shader_cache_entry_init(Lru *lru, LruNode *node, void *state)
@@ -393,7 +396,7 @@ static ShaderBinding *gen_shaders(PGRAPHState *pg, ShaderState *state)
 
         MString *geometry_shader_code = pgraph_gen_geom_glsl(
             state->polygon_front_mode, state->polygon_back_mode,
-            state->primitive_mode, state->smooth_shading, true);
+            state->primitive_mode, state->smooth_shading, true, state->z_perspective);
         if (geometry_shader_code) {
             NV2A_VK_DPRINTF("geometry shader: \n%s",
                             mstring_get_str(geometry_shader_code));
@@ -414,7 +417,7 @@ static ShaderBinding *gen_shaders(PGRAPHState *pg, ShaderState *state)
             mstring_get_str(vertex_shader_code));
         mstring_unref(vertex_shader_code);
 
-        MString *fragment_shader_code = pgraph_gen_psh_glsl(state->psh);
+        MString *fragment_shader_code = pgraph_gen_psh_glsl(state->psh, state->z_perspective);
         NV2A_VK_DPRINTF("fragment shader: \n%s",
                         mstring_get_str(fragment_shader_code));
         snode->fragment = pgraph_vk_create_shader_module_from_glsl(
@@ -640,16 +643,21 @@ static void shader_update_constants(PGRAPHState *pg, ShaderBinding *binding,
                          pg->surface_binding_dim.height / aa_height);
     }
 
-    if (binding->clip_range_loc != -1) {
-        uint32_t v[2];
-        v[0] = pgraph_reg_r(pg, NV_PGRAPH_ZCLIPMIN);
-        v[1] = pgraph_reg_r(pg, NV_PGRAPH_ZCLIPMAX);
-        float zclip_min = *(float *)&v[0] / zmax * 2.0 - 1.0;
-        float zclip_max = *(float *)&v[1] / zmax * 2.0 - 1.0;
+    uint32_t v[2];
+    v[0] = pgraph_reg_r(pg, NV_PGRAPH_ZCLIPMIN);
+    v[1] = pgraph_reg_r(pg, NV_PGRAPH_ZCLIPMAX);
+    float zclip_min = *(float *)&v[0] / zmax * 2.0 - 1.0;
+    float zclip_max = *(float *)&v[1] / zmax * 2.0 - 1.0;
+
+    if (binding->clip_range_loc != -1) {       
         uniform4f(&binding->vertex->uniforms, binding->clip_range_loc, 0,
                          zmax, zclip_min, zclip_max);
     }
 
+    if (binding->clip_range_loc_frag != -1) {
+        uniform4f(&binding->fragment->uniforms, binding->clip_range_loc_frag, 0,
+                  zmax, zclip_min, zclip_max);
+    }
     /* Clipping regions */
     unsigned int max_gl_width = pg->surface_binding_dim.width;
     unsigned int max_gl_height = pg->surface_binding_dim.height;


### PR DESCRIPTION
Passing clipRange variable as a uniform and performing perspective divide in fragment shader for z_perspective = true solves the see through issue that affects many games.

Shader code for z_perspective = false is virtually unaltered.