### PR TITLE
Enable depth clamp for texture perspective

### DIFF
--- a/hw/xbox/nv2a/pgraph/gl/draw.c
+++ b/hw/xbox/nv2a/pgraph/gl/draw.c
@@ -146,8 +146,11 @@ void pgraph_gl_draw_begin(NV2AState *d)
     bool mask_blue = control_0 & NV_PGRAPH_CONTROL_0_BLUE_WRITE_ENABLE;
     bool color_write = mask_alpha || mask_red || mask_green || mask_blue;
     bool depth_test = control_0 & NV_PGRAPH_CONTROL_0_ZENABLE;
+    bool z_persp = control_0 & NV_PGRAPH_CONTROL_0_Z_PERSPECTIVE_ENABLE;
     bool stencil_test =
         pgraph_reg_r(pg, NV_PGRAPH_CONTROL_1) & NV_PGRAPH_CONTROL_1_STENCIL_TEST_ENABLE;
+    bool tex_persp =
+        pgraph_reg_r(pg, NV_PGRAPH_CONTROL_3) & NV_PGRAPH_CONTROL_3_TEXTURE_PERSPECTIVE_ENABLE;
     bool is_nop_draw = !(color_write || depth_test || stencil_test);
 
     pgraph_gl_surface_update(d, true, true, depth_test || stencil_test);
@@ -257,7 +260,7 @@ void pgraph_gl_draw_begin(NV2AState *d)
 
     if (GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_ZCOMPRESSOCCLUDE),
                  NV_PGRAPH_ZCOMPRESSOCCLUDE_ZCLAMP_EN) ==
-        NV_PGRAPH_ZCOMPRESSOCCLUDE_ZCLAMP_EN_CLAMP) {
+        NV_PGRAPH_ZCOMPRESSOCCLUDE_ZCLAMP_EN_CLAMP || (tex_persp && !z_persp)) {
         glEnable(GL_DEPTH_CLAMP);
     } else {
         glDisable(GL_DEPTH_CLAMP);

--- a/hw/xbox/nv2a/pgraph/glsl/vsh-prog.c
+++ b/hw/xbox/nv2a/pgraph/glsl/vsh-prog.c
@@ -860,29 +860,13 @@ void pgraph_gen_vsh_prog_glsl(uint16_t version,
 
     mstring_append(body,
         "  if (clipRange.y != clipRange.x) {\n");
-    if (texture) {  
-        if (z_perspective) {
-            if (vulkan) {
+
+    if (z_perspective) {
+        if (vulkan) {
                 mstring_append(body, "    oPos.z = (oPos.z - clipRange.z)/(clipRange.w - clipRange.z);\n");
-            } else {
-                mstring_append(body, "    oPos.z = (oPos.z - clipRange.z)/(0.5*(clipRange.w - clipRange.z)) - 1;\n");
-            }
         } else {
-            /* There is some clip distance / clip range issue here; if using x and y as near and far planes,
-             * character shadows in many games get clipped (e.g. Conker, Halo CE, Wallace & Gromit), 
-             * and using z and w as near and far planes restores them but the Xbox dashboard background 
-             * gets clipped. Set / disable gl_clipDistance? ( x = 0, y = zmax, z = zclipmin, w = zclipmax ) */
-            if (vulkan) {
-                mstring_append(body, "    oPos.z = (oPos.z - clipRange.x)/(clipRange.y - clipRange.x);\n");
-            } else {
-                mstring_append(body, "    oPos.z = (oPos.z - clipRange.x)/(0.5*(clipRange.y - clipRange.x)) - 1;\n");
-            }
+                mstring_append(body, "    oPos.z = (oPos.z - clipRange.z)/(0.5*(clipRange.w - clipRange.z)) - 1;\n");
         }
-        mstring_append(body,
-            "  }\n"
-        );  
-    
-        mstring_append(body, "  oPos.xyz *= oPos.w;\n");
     } else {
         if (vulkan) {
             mstring_append(body, "    oPos.z = (oPos.z - clipRange.x)/(clipRange.y - clipRange.x);\n");
@@ -891,9 +875,14 @@ void pgraph_gen_vsh_prog_glsl(uint16_t version,
                            "    oPos.z = (oPos.z - clipRange.x)/(0.5*(clipRange.y "
                            "- clipRange.x)) - 1;\n");
         }
+    }
         mstring_append(body,
             "  }\n"
         );
+    if (z_perspective || texture) {
+            mstring_append(body, "  oPos.xyz *= oPos.w;\n");
+    } else {
+    
         mstring_append(
             body,
 

--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -738,9 +738,12 @@ static void create_pipeline(PGRAPHState *pg)
 
     uint32_t control_0 = pgraph_reg_r(pg, NV_PGRAPH_CONTROL_0);
     bool depth_test = control_0 & NV_PGRAPH_CONTROL_0_ZENABLE;
+    bool z_persp = control_0 & NV_PGRAPH_CONTROL_0_Z_PERSPECTIVE_ENABLE;
     bool depth_write = !!(control_0 & NV_PGRAPH_CONTROL_0_ZWRITEENABLE);
     bool stencil_test =
         pgraph_reg_r(pg, NV_PGRAPH_CONTROL_1) & NV_PGRAPH_CONTROL_1_STENCIL_TEST_ENABLE;
+    bool tex_persp =
+        pgraph_reg_r(pg, NV_PGRAPH_CONTROL_3) & NV_PGRAPH_CONTROL_3_TEXTURE_PERSPECTIVE_ENABLE;
 
     int num_active_shader_stages = 0;
     VkPipelineShaderStageCreateInfo shader_stages[3];
@@ -985,7 +988,7 @@ static void create_pipeline(PGRAPHState *pg)
 
     if (GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_ZCOMPRESSOCCLUDE),
                  NV_PGRAPH_ZCOMPRESSOCCLUDE_ZCLAMP_EN) ==
-        NV_PGRAPH_ZCOMPRESSOCCLUDE_ZCLAMP_EN_CLAMP) {
+        NV_PGRAPH_ZCOMPRESSOCCLUDE_ZCLAMP_EN_CLAMP || (tex_persp && !z_persp)) {
         rasterizer.depthClampEnable = VK_TRUE;
     }
 


### PR DESCRIPTION
Restores shadows for many games in #577 w/o removing the Xbox dashboard background