### PR TITLE
nv2a: Fix cubemap fourth texture coordinate component handling

### DIFF
--- a/hw/xbox/nv2a/pgraph/glsl/psh.c
+++ b/hw/xbox/nv2a/pgraph/glsl/psh.c
@@ -984,8 +984,8 @@ static MString* psh_convert(struct PixelShader *ps)
             }
             break;
         case PS_TEXTUREMODES_CUBEMAP:
-            mstring_append_fmt(vars, "vec4 t%d = texture(texSamp%d, pT%d.xyz / pT%d.w);\n",
-                               i, i, i, i);
+            mstring_append_fmt(vars, "vec4 t%d = texture(texSamp%d, pT%d.xyz);\n",
+                               i, i, i);
             break;
         case PS_TEXTUREMODES_PASSTHRU:
             assert(ps->state.border_logical_size[i][0] == 0.0f && "Unexpected border texture on passthru");


### PR DESCRIPTION
Xbox hardware ignores fourth texture coordinate component for cubemaps.