### PR TITLE
nv2a/gl/vk: Add an anisotropic filtering option to the graphics setti…

### DIFF
--- a/config_spec.yml
+++ b/config_spec.yml
@@ -146,6 +146,9 @@ display:
     surface_scale:
       type: integer
       default: 1
+    anisotropic_filter_level:
+      type: integer
+      default: 1
   window:
     fullscreen_on_startup: bool
     fullscreen_exclusive: bool

--- a/hw/xbox/nv2a/nv2a.h
+++ b/hw/xbox/nv2a/nv2a.h
@@ -27,6 +27,8 @@ int nv2a_get_framebuffer_surface(void);
 void nv2a_release_framebuffer_surface(void);
 void nv2a_set_surface_scale_factor(unsigned int scale);
 unsigned int nv2a_get_surface_scale_factor(void);
+void nv2a_set_anisotropic_filter_level(unsigned int level_po2);
+unsigned int nv2a_get_anisotropic_filter_level(void);
 const uint8_t *nv2a_get_dac_palette(void);
 int nv2a_get_screen_off(void);
 

--- a/hw/xbox/nv2a/pgraph/gl/renderer.c
+++ b/hw/xbox/nv2a/pgraph/gl/renderer.c
@@ -194,6 +194,8 @@ static PGRAPHRenderer pgraph_gl_renderer = {
         .surface_update = pgraph_gl_surface_update,
         .set_surface_scale_factor = pgraph_gl_set_surface_scale_factor,
         .get_surface_scale_factor = pgraph_gl_get_surface_scale_factor,
+        .set_anisotropic_filter_level = pgraph_gl_set_anisotropic_filter_level,
+        .get_anisotropic_filter_level = pgraph_gl_get_anisotropic_filter_level,
         .get_framebuffer_surface = pgraph_gl_get_framebuffer_surface,
     }
 };

--- a/hw/xbox/nv2a/pgraph/gl/renderer.h
+++ b/hw/xbox/nv2a/pgraph/gl/renderer.h
@@ -284,6 +284,9 @@ bool pgraph_gl_shader_load_from_memory(ShaderBinding *snode);
 void pgraph_gl_shader_write_cache_reload_list(PGRAPHState *pg);
 void pgraph_gl_set_surface_scale_factor(NV2AState *d, unsigned int scale);
 unsigned int pgraph_gl_get_surface_scale_factor(NV2AState *d);
+void pgraph_gl_set_anisotropic_filter_level(NV2AState *d, unsigned int level_po2);
+unsigned int pgraph_gl_get_anisotropic_filter_level(NV2AState *d);
+void pgraph_gl_reload_anisotropic_filter_level(PGRAPHState *pg);
 int pgraph_gl_get_framebuffer_surface(NV2AState *d);
 
 #endif

--- a/hw/xbox/nv2a/pgraph/pgraph.c
+++ b/hw/xbox/nv2a/pgraph/pgraph.c
@@ -406,6 +406,35 @@ unsigned int nv2a_get_surface_scale_factor(void)
     return s;
 }
 
+void nv2a_set_anisotropic_filter_level(unsigned int level_po2)
+{
+    NV2AState *d = g_nv2a;
+
+    bql_unlock();
+    qemu_mutex_lock(&d->pgraph.renderer_lock);
+    if (d->pgraph.renderer->ops.set_anisotropic_filter_level) {
+        d->pgraph.renderer->ops.set_anisotropic_filter_level(d, level_po2);
+    }
+    qemu_mutex_unlock(&d->pgraph.renderer_lock);
+    bql_lock();
+}
+
+unsigned int nv2a_get_anisotropic_filter_level(void)
+{
+    NV2AState *d = g_nv2a;
+    int s = 1;
+
+    bql_unlock();
+    qemu_mutex_lock(&d->pgraph.renderer_lock);
+    if (d->pgraph.renderer->ops.get_anisotropic_filter_level) {
+        s = d->pgraph.renderer->ops.get_anisotropic_filter_level(d);
+    }
+    qemu_mutex_unlock(&d->pgraph.renderer_lock);
+    bql_lock();
+
+    return s;
+}
+
 #define METHOD_ADDR(gclass, name) \
     gclass ## _ ## name
 #define METHOD_ADDR_TO_INDEX(x) ((x)>>2)
@@ -3022,4 +3051,3 @@ void pgraph_pre_shutdown_wait(NV2AState *d)
     PGRAPHState *pg = &d->pgraph;
     pg->renderer->ops.pre_shutdown_wait(d);
 }
-

--- a/hw/xbox/nv2a/pgraph/pgraph.h
+++ b/hw/xbox/nv2a/pgraph/pgraph.h
@@ -120,6 +120,8 @@ typedef struct PGRAPHRenderer {
         void (*surface_update)(NV2AState *d, bool upload, bool color_write, bool zeta_write);
         void (*set_surface_scale_factor)(NV2AState *d, unsigned int scale);
         unsigned int (*get_surface_scale_factor)(NV2AState *d);
+        void (*set_anisotropic_filter_level)(NV2AState *d, unsigned int level_po2);
+        unsigned int (*get_anisotropic_filter_level)(NV2AState *d);
         int (*get_framebuffer_surface)(NV2AState *d);
     } ops;
 } PGRAPHRenderer;
@@ -240,6 +242,9 @@ typedef struct PGRAPHState {
 
     unsigned int surface_scale_factor;
     uint8_t *scale_buf;
+
+    // Defined as a power of 2
+    unsigned int anisotropic_filter_level;
 
     const PGRAPHRenderer *renderer;
     union {

--- a/hw/xbox/nv2a/pgraph/vk/renderer.c
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.c
@@ -164,7 +164,7 @@ static void pgraph_vk_pre_shutdown_trigger(NV2AState *d)
 
 static void pgraph_vk_pre_shutdown_wait(NV2AState *d)
 {
-    // qemu_event_wait(&d->pgraph.vk_renderer_state->shader_cache_writeback_complete);   
+    // qemu_event_wait(&d->pgraph.vk_renderer_state->shader_cache_writeback_complete);
 }
 
 static int pgraph_vk_get_framebuffer_surface(NV2AState *d)
@@ -226,6 +226,8 @@ static PGRAPHRenderer pgraph_vk_renderer = {
         .surface_update = pgraph_vk_surface_update,
         .set_surface_scale_factor = pgraph_vk_set_surface_scale_factor,
         .get_surface_scale_factor = pgraph_vk_get_surface_scale_factor,
+        .set_anisotropic_filter_level = pgraph_vk_set_anisotropic_filter_level,
+        .get_anisotropic_filter_level = pgraph_vk_get_anisotropic_filter_level,
         .get_framebuffer_surface = pgraph_vk_get_framebuffer_surface,
     }
 };

--- a/hw/xbox/nv2a/pgraph/vk/renderer.h
+++ b/hw/xbox/nv2a/pgraph/vk/renderer.h
@@ -544,6 +544,9 @@ void pgraph_vk_bind_textures(NV2AState *d);
 void pgraph_vk_mark_textures_possibly_dirty(NV2AState *d, hwaddr addr,
                                             hwaddr size);
 void pgraph_vk_trim_texture_cache(PGRAPHState *pg);
+void pgraph_vk_set_anisotropic_filter_level(NV2AState *d, unsigned int level_po2);
+unsigned int pgraph_vk_get_anisotropic_filter_level(NV2AState *d);
+void pgraph_vk_reload_anisotropic_filter_level(PGRAPHState *pg);
 
 // shaders.c
 void pgraph_vk_init_shaders(PGRAPHState *pg);

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -172,14 +172,14 @@ void MainMenuInputView::Draw()
         driver = DRIVER_DUKE_DISPLAY_NAME;
     else if (strcmp(driver, DRIVER_S) == 0)
         driver = DRIVER_S_DISPLAY_NAME;
-    
+
     ImGui::SetNextItemWidth(-FLT_MIN);
     if (ImGui::BeginCombo("###InputDrivers", driver,
                           ImGuiComboFlags_NoArrowButton)) {
         const char *available_drivers[] = { DRIVER_DUKE, DRIVER_S };
-        const char *driver_display_names[] = { 
-            DRIVER_DUKE_DISPLAY_NAME, 
-            DRIVER_S_DISPLAY_NAME 
+        const char *driver_display_names[] = {
+            DRIVER_DUKE_DISPLAY_NAME,
+            DRIVER_S_DISPLAY_NAME
             };
         bool is_selected = false;
         int num_drivers = sizeof(driver_display_names) / sizeof(driver_display_names[0]);
@@ -513,8 +513,19 @@ void MainMenuDisplayView::Draw()
                      "8x\0"
                      "9x\0"
                      "10x\0",
-                     "Increase surface scaling factor for higher quality")) {
+                     "Increase surface scaling factor for higher overall quality")) {
         nv2a_set_surface_scale_factor(rendering_scale+1);
+    }
+
+    int anisotropic_filter_level = nv2a_get_anisotropic_filter_level();
+    if (ChevronCombo("Anisotropic filtering level", &anisotropic_filter_level,
+                     "Disabled\0"
+                     "2x\0"
+                     "4x\0"
+                     "8x\0"
+                     "16x\0",
+                     "Increase anisotropic filtering level for sharper textures at oblique angles")) {
+        nv2a_set_anisotropic_filter_level(anisotropic_filter_level);
     }
 
     SectionTitle("Window");

--- a/ui/xui/menubar.cc
+++ b/ui/xui/menubar.cc
@@ -192,6 +192,16 @@ void ShowMainMenu()
                 nv2a_set_surface_scale_factor(rendering_scale + 1);
             }
 
+            int anisotropic_filter_level = nv2a_get_anisotropic_filter_level();
+            if (ImGui::Combo("Anisotropic Filtering Level", &anisotropic_filter_level,
+                             "Disabled\0"
+                             "2x\0"
+                             "4x\0"
+                             "8x\0"
+                             "16x\0")) {
+                nv2a_set_anisotropic_filter_level(anisotropic_filter_level);
+            }
+
             ImGui::Combo("Display Mode", &g_config.display.ui.fit,
                          "Center\0Scale\0Stretch\0");
             ImGui::SameLine();


### PR DESCRIPTION
…ngs menu

This is available in both Vulkan and OpenGL renderers. Note that the Vulkan renderer requires a restart for changes to be effective, while changes in OpenGL are applied immediately.