### PR TITLE
nv2a: Fix DstAlpha blending for const-alpha surface modes

### DIFF
--- a/hw/xbox/nv2a/pgraph/gl/draw.c
+++ b/hw/xbox/nv2a/pgraph/gl/draw.c
@@ -127,7 +127,7 @@ void pgraph_gl_clear_surface(NV2AState *d, uint32_t parameter)
     if (r->zeta_binding) {
         r->zeta_binding->cleared = full_clear && write_zeta;
     }
-    
+
     pg->clearing = false;
 }
 
@@ -167,10 +167,15 @@ void pgraph_gl_draw_begin(NV2AState *d)
 
     if (pgraph_reg_r(pg, NV_PGRAPH_BLEND) & NV_PGRAPH_BLEND_EN) {
         glEnable(GL_BLEND);
-        uint32_t sfactor = GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_BLEND),
-                                    NV_PGRAPH_BLEND_SFACTOR);
-        uint32_t dfactor = GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_BLEND),
-                                    NV_PGRAPH_BLEND_DFACTOR);
+        uint32_t sfactor = fixup_blend_factor_for_surface(
+            GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_BLEND),
+                     NV_PGRAPH_BLEND_SFACTOR),
+            &pg->surface_shape);
+        uint32_t dfactor = fixup_blend_factor_for_surface(
+            GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_BLEND),
+                     NV_PGRAPH_BLEND_DFACTOR),
+            &pg->surface_shape);
+
         assert(sfactor < ARRAY_SIZE(pgraph_blend_factor_gl_map));
         assert(dfactor < ARRAY_SIZE(pgraph_blend_factor_gl_map));
         glBlendFunc(pgraph_blend_factor_gl_map[sfactor],

--- a/hw/xbox/nv2a/pgraph/meson.build
+++ b/hw/xbox/nv2a/pgraph/meson.build
@@ -3,6 +3,7 @@ specific_ss.add(files(
 	'profile.c',
 	'rdi.c',
 	's3tc.c',
+	'surface.c',
 	'swizzle.c',
 	'texture.c',
 	'vertex.c',

--- a/hw/xbox/nv2a/pgraph/surface.c
+++ b/hw/xbox/nv2a/pgraph/surface.c
@@ -1,0 +1,57 @@
+/*
+ * QEMU Geforce NV2A implementation
+ *
+ * Copyright (c) 2012 espes
+ * Copyright (c) 2015 Jannik Vogel
+ * Copyright (c) 2018-2025 Matt Borgerson
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "surface.h"
+
+#include "hw/xbox/nv2a/nv2a_regs.h"
+
+uint32_t fixup_blend_factor_for_surface(uint32_t blend_factor,
+                                        const struct SurfaceShape *surface)
+{
+    switch (surface->color_format) {
+    case NV097_SET_SURFACE_FORMAT_COLOR_LE_X1R5G5B5_Z1R5G5B5:
+    case NV097_SET_SURFACE_FORMAT_COLOR_LE_X1R5G5B5_O1R5G5B5:
+    case NV097_SET_SURFACE_FORMAT_COLOR_LE_X8R8G8B8_Z8R8G8B8:
+    case NV097_SET_SURFACE_FORMAT_COLOR_LE_X8R8G8B8_O8R8G8B8:
+    case NV097_SET_SURFACE_FORMAT_COLOR_LE_X1A7R8G8B8_Z1A7R8G8B8:
+    case NV097_SET_SURFACE_FORMAT_COLOR_LE_X1A7R8G8B8_O1A7R8G8B8:
+        if (blend_factor == NV_PGRAPH_BLEND_SFACTOR_DST_ALPHA) {
+            return NV_PGRAPH_BLEND_SFACTOR_ONE;
+        }
+        if (blend_factor ==
+            NV_PGRAPH_BLEND_SFACTOR_ONE_MINUS_DST_ALPHA) {
+            return NV_PGRAPH_BLEND_SFACTOR_ZERO;
+        }
+        if (blend_factor == NV_PGRAPH_BLEND_DFACTOR_DST_ALPHA) {
+            return NV_PGRAPH_BLEND_DFACTOR_ONE;
+        }
+        if (blend_factor ==
+            NV_PGRAPH_BLEND_DFACTOR_ONE_MINUS_DST_ALPHA) {
+            return NV_PGRAPH_BLEND_DFACTOR_ZERO;
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    return blend_factor;
+}

--- a/hw/xbox/nv2a/pgraph/surface.h
+++ b/hw/xbox/nv2a/pgraph/surface.h
@@ -22,6 +22,8 @@
 #ifndef HW_XBOX_NV2A_PGRAPH_SURFACE_H
 #define HW_XBOX_NV2A_PGRAPH_SURFACE_H
 
+#include <stdint.h>
+
 typedef struct SurfaceShape {
     unsigned int z_format;
     unsigned int color_format;
@@ -31,5 +33,10 @@ typedef struct SurfaceShape {
     unsigned int clip_width, clip_height;
     unsigned int anti_aliasing;
 } SurfaceShape;
+
+/**
+ * Returns a modified blend factor to match HW behavior for special surface formats.
+ */
+uint32_t fixup_blend_factor_for_surface(uint32_t blend_factor, const struct SurfaceShape *surface);
 
 #endif

--- a/hw/xbox/nv2a/pgraph/vk/draw.c
+++ b/hw/xbox/nv2a/pgraph/vk/draw.c
@@ -908,10 +908,15 @@ static void create_pipeline(PGRAPHState *pg)
     if (pgraph_reg_r(pg, NV_PGRAPH_BLEND) & NV_PGRAPH_BLEND_EN) {
         color_blend_attachment.blendEnable = VK_TRUE;
 
-        uint32_t sfactor =
-            GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_BLEND), NV_PGRAPH_BLEND_SFACTOR);
-        uint32_t dfactor =
-            GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_BLEND), NV_PGRAPH_BLEND_DFACTOR);
+        uint32_t sfactor = fixup_blend_factor_for_surface(
+            GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_BLEND),
+                     NV_PGRAPH_BLEND_SFACTOR),
+            &pg->surface_shape);
+        uint32_t dfactor = fixup_blend_factor_for_surface(
+            GET_MASK(pgraph_reg_r(pg, NV_PGRAPH_BLEND),
+                     NV_PGRAPH_BLEND_DFACTOR),
+            &pg->surface_shape);
+
         assert(sfactor < ARRAY_SIZE(pgraph_blend_factor_vk_map));
         assert(dfactor < ARRAY_SIZE(pgraph_blend_factor_vk_map));
         color_blend_attachment.srcColorBlendFactor =


### PR DESCRIPTION
This remaps DstAlpha to alternate source/destination factors when performing blending on target surfaces with forced alpha bits (e.g., NV097_SET_SURFACE_FORMAT_COLOR_LE_X8R8G8B8_Z8R8G8B8).

Fixes #2473

Tests: https://github.com/abaire/nxdk_pgraph_tests/blob/de548172ac3166f03f3a75999829ba17aade73aa/src/tests/blend_surface_tests.cpp#L249
HW results: https://abaire.github.io/nxdk_pgraph_tests_golden_results/results/Blend_surface/index.html