### PR TITLE
nv2a: Add lock-free fast path for fence polling reads

### DIFF
--- a/hw/xbox/nv2a/pgraph/pgraph.c
+++ b/hw/xbox/nv2a/pgraph/pgraph.c
@@ -44,6 +44,28 @@ uint64_t pgraph_read(void *opaque, hwaddr addr, unsigned int size)
     NV2AState *d = (NV2AState *)opaque;
     PGRAPHState *pg = &d->pgraph;
 
+    /*
+     * Lock-free fast path for the GPU fence register the guest busy-polls.
+     * The Xbox D3D runtime polls NV_PGRAPH_PATT_COLOR0 for its fence value;
+     * taking pg->lock for each poll convoys with the FIFO puller, which
+     * needs the same lock to advance the fence being polled for. A
+     * momentarily stale read is what real hardware gives a CPU polling an
+     * asynchronously updated register. The write side is serialized: the
+     * fence method runs under pg->lock, and guest MMIO writes to this
+     * register are issued by the same single vCPU that polls it.
+     */
+    if (size == 4 && addr == NV_PGRAPH_PATT_COLOR0) {
+        uint64_t fr = qatomic_read(&pg->regs_[NV_PGRAPH_PATT_COLOR0]);
+        /*
+         * Pairs with the smp_wmb at the fence write site in pgraph_method,
+         * so that the pgraph effects preceding the fence are visible once
+         * the new fence value is.
+         */
+        smp_rmb();
+        nv2a_reg_log_read(NV_PGRAPH, addr, size, fr);
+        return fr;
+    }
+
     qemu_mutex_lock(&pg->lock);
 
     uint64_t r = 0;
@@ -702,7 +724,14 @@ int pgraph_method(NV2AState *d, unsigned int subchannel,
     case NV_CONTEXT_PATTERN: {
         switch (method) {
         case NV044_SET_MONOCHROME_COLOR0:
-            pgraph_reg_w(pg, NV_PGRAPH_PATT_COLOR0, parameter);
+            /*
+             * Xbox D3D GPU fence value, busy-polled by the guest CPU; see
+             * the lock-free read path in pgraph_read. The barrier orders
+             * the pgraph effects of preceding methods before the fence
+             * store becomes visible to the polling vCPU.
+             */
+            smp_wmb();
+            pgraph_reg_w_atomic(pg, NV_PGRAPH_PATT_COLOR0, parameter);
             break;
         default:
             goto unhandled;

--- a/hw/xbox/nv2a/pgraph/pgraph.h
+++ b/hw/xbox/nv2a/pgraph/pgraph.h
@@ -315,6 +315,22 @@ static inline void pgraph_reg_w(PGRAPHState *pg, unsigned int r, uint32_t v)
     pg->regs_[r] = v;
 }
 
+/*
+ * Variant of pgraph_reg_w for registers that pgraph_read serves without
+ * taking pg->lock: the atomic store keeps the compiler from tearing or
+ * eliding the write under a concurrent lock-free reader. Writers remain
+ * serialized by pg->lock, so the dirty-tracking compare can stay plain.
+ */
+static inline void pgraph_reg_w_atomic(PGRAPHState *pg, unsigned int r,
+                                       uint32_t v)
+{
+    assert(r % 4 == 0);
+    if (pg->regs_[r] != v) {
+        bitmap_set(pg->regs_dirty, r / sizeof(uint32_t), 1);
+    }
+    qatomic_set(&pg->regs_[r], v);
+}
+
 void pgraph_clear_dirty_reg_map(PGRAPHState *pg);
 
 static inline bool pgraph_is_reg_dirty(PGRAPHState *pg, unsigned int reg)


### PR DESCRIPTION
The Xbox D3D runtime implements GPU fences by writing a sequence number into NV_PGRAPH_PATT_COLOR0 (via NV044_SET_MONOCHROME_COLOR0 in the pushbuffer) and busy-polling the register from the CPU until the value appears.

Profiling Project Gotham Racing 2 races showed ~580k MMIO reads of this single register per minute of gameplay, an order of magnitude more than all other PGRAPH register accesses combined. Every poll acquired pgraph.lock, contending with the FIFO puller thread that takes the same lock to process the methods which advance the fence being awaited. The resulting lock convoy serialized the vCPU and FIFO threads at roughly 11us per draw batch; with the 3500-5000 batches per frame these scenes submit, heavy races collapsed to 10-20 fps while neither any host thread nor the host GPU was saturated.

Serve aligned 32-bit reads of NV_PGRAPH_PATT_COLOR0 with a lock-free snapshot instead. A momentarily stale value matches real hardware behavior for a CPU polling an asynchronously updated register. The fence store becomes qatomic_set so it cannot race the lock-free reader, and an smp_wmb at the write site pairs with an smp_rmb in the read path so the new fence value cannot be observed before the pgraph effects that precede it, on weakly ordered hosts as well. The write side remains serialized: the fence method runs under pgraph.lock, and guest MMIO writes to the register come from the same single vCPU that polls it.

Measured on PGR2 (PAL, GTX 1060 / Windows 11): a heavy 6-car race scene improves from 17-19 fps at ~35% game speed to a locked 30 fps at 100% game speed (verified against the in-game lap timer). Rendering and audio verified over multiple complete races.

Fixes #1376